### PR TITLE
Update readme to specify sort collation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Redeemer normally reaps *most* of the initial creation delegation (leaving them 
 
 1. Make a new branch
 1. Check in file using `YYYYMMDD.filename.txt` format (optionally removing old version)
-1. Run `make` to regenerate `full.txt` (which is derived data and technically shouldn't be in git, but the file is actually fetched from `github.com` by redeemer so the full list needs to be in git).
+1. Run `make` to regenerate `full.txt` (which is derived data and technically shouldn't be in git, but the file is actually fetched from `github.com` by redeemer so the full list needs to be in git). Note: the sorting of the records in the full.txt file uses "C" collation.
 1. Create a PR to `master`.
 
 # See also


### PR DESCRIPTION
When following the instructions on an Ubuntu 16.04 system, the resulting full.txt file was in a different order than the file in the repository. This PR updates the readme to specify that the sorting is done using "C" collation.